### PR TITLE
Remove the Grid and Grid Centering to avoid field labels being centered.

### DIFF
--- a/lib/at_semantic-ui.css
+++ b/lib/at_semantic-ui.css
@@ -11,6 +11,12 @@
 .at-left {
   text-align: left !important;
 }
+.at-grid {
+  height: 100%;
+}
+.at-column {
+  max-width: 520px;
+}
 .at-input.validating * {
   cursor: progress;
 }

--- a/lib/full_page_at_form.html
+++ b/lib/full_page_at_form.html
@@ -1,5 +1,5 @@
 <template name="fullPageAtForm">
-  <div class="at-container ui middle aligned centered grid">
+  <div class="at-grid ui middle aligned centered grid">
     <div class="at-column column">
       {{> atForm}}
     </div>

--- a/lib/full_page_at_form.html
+++ b/lib/full_page_at_form.html
@@ -1,7 +1,5 @@
 <template name="fullPageAtForm">
-  <div class="at-grid ui center aligned grid">
-    <div class="at-column middle aligned column">
-      {{> atForm}}
-    </div>
+  <div class="at-grid ui container">
+    {{> atForm}}
   </div>
 </template>

--- a/lib/full_page_at_form.html
+++ b/lib/full_page_at_form.html
@@ -1,5 +1,7 @@
 <template name="fullPageAtForm">
-  <div class="at-grid ui container">
-    {{> atForm}}
+  <div class="at-container ui middle aligned centered grid">
+    <div class="at-column column">
+      {{> atForm}}
+    </div>
   </div>
 </template>


### PR DESCRIPTION
The Semantic 2.0 changes seem to have created some funny situations with the centering of field labels.  Prior to the 2.0 upgrade, the forms looked as...

<img width="1128" alt="screen shot 2015-08-22 at 6 37 53 pm" src="https://cloud.githubusercontent.com/assets/841294/9424673/12bddec4-48fd-11e5-9176-0e9acf94e3a8.png">

However, after the update to 2.0, the use of a `center aligned grid` (instead of the `center aligned page grid` which was deprecated in Semantic 2.0) has cause the field labels to be centered on a fluid-width form, which is contrary to the left-aligned labels that Semantic provides natively.

<img width="1128" alt="screen shot 2015-08-22 at 6 38 17 pm" src="https://cloud.githubusercontent.com/assets/841294/9424674/1b842e00-48fd-11e5-99d0-f1e9a7dba7a6.png">

This change will restore a similar alignment as to the 1.0 version and remove the use of `grid` and `column`, which are not necessary for such a simple layout...  This pull request leaves the form as a fluid width, but left-aligned.  As follows...

<img width="1131" alt="screen shot 2015-08-22 at 6 38 44 pm" src="https://cloud.githubusercontent.com/assets/841294/9424675/23583b1c-48fd-11e5-87b6-778ca23156ff.png">

I believe this would be a more desirable behavior than the center-aligned labels, especially on larger monitors, and is the standard setup for the [Semantic UI Form](http://semantic-ui.com/collections/form.html) collection.