### PR TITLE
at_social.js: use 'windows' icon when service is named 'microsoft'

### DIFF
--- a/lib/at_social.js
+++ b/lib/at_social.js
@@ -12,6 +12,8 @@ Template.atSocial.helpers({
     var classStr = this._id;
     if (classStr === 'google')
       classStr += ' plus';
+    if (classStr === 'microsoft')
+      classStr = 'windows';
     return classStr;
   },
 });


### PR DESCRIPTION
This patch is to support an additional social login package 'clarktlaugh:accounts-microsoft' where the service name is 'microsoft' and no icon appears.

The 'useraccounts:semantic-ui' package prevents the normal method of overriding the social icons that useraccounts provides (https://github.com/meteor-useraccounts/core/blob/master/Guide.md#social-button-icons), and naming the "Microsoft Account" login "Windows" in order to get the icon to show up would be confusing to the user.

This patch simply provides an "alias" for the icon class name.
